### PR TITLE
MediaStream.stop() deprecated function fix

### DIFF
--- a/js/opentok-hardware-setup.js
+++ b/js/opentok-hardware-setup.js
@@ -286,7 +286,16 @@ var authenticateForDeviceLabels = function(callback) {
             return callback(new Error('getUserMedia not supported in this browser'));
           }
           getUserMedia(constraints, function(stream) {
-            stream.stop();
+            if (stream.stop) {
+                // Older spec
+                stream.stop();
+            } else {
+                // Newer spec
+                var tracks = stream.getAudioTracks().concat(stream.getVideoTracks());
+                tracks.forEach(function(track) {
+                  track.stop();
+                });
+            }
             callback();
           }, function(error) {
             var err = new Error(gumNamesToMessages[error.name]);

--- a/js/opentok-hardware-setup.js
+++ b/js/opentok-hardware-setup.js
@@ -286,15 +286,14 @@ var authenticateForDeviceLabels = function(callback) {
             return callback(new Error('getUserMedia not supported in this browser'));
           }
           getUserMedia(constraints, function(stream) {
-            if (stream.stop) {
-                // Older spec
-                stream.stop();
-            } else {
-                // Newer spec
-                var tracks = stream.getAudioTracks().concat(stream.getVideoTracks());
-                tracks.forEach(function(track) {
-                  track.stop();
-                });
+            if (window.MediaStreamTrack && window.MediaStreamTrack.prototype.stop) {
+              var tracks = stream.getTracks();
+              tracks.forEach(function(track) {
+                track.stop();
+              });
+            } else if (stream.stop) {
+             // older spec
+             stream.stop();
             }
             callback();
           }, function(error) {


### PR DESCRIPTION
Once MediaStream.stop() function was deprecated, the code was fixed to work in Chrome 47+.