### PR TITLE
Add optional handlers for publisher errors, access denied, and audio level change

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,21 +82,28 @@ parameters:
 * `targetElement` -- The DOM element in which to insert the hardware setup
 component. (See the insertMode property of the next parameter, options.)
 
-* `options` -- An optional argument that specifies how the component will be
+* `options`
+
+  * `targetElement` --  An optional argument that specifies how the component will be
 inserted in the HTML DOM, in relation to the targetElement parameter. You can
 set this parameter to one of the following values:
-
-  * `"replace"` -- The component replaces contents of the targetElement. This is
+      * `"replace"` -- The component replaces contents of the targetElement. This is
 the default.
-  * `"after"` -- The component is a new element inserted after the targetElement in
+      * `"after"` -- The component is a new element inserted after the targetElement in
 the HTML DOM. (Both the component and targetElement have the same parent
 element.)
-  * `"before"` -- The component is a new element inserted before the targetElement
+      * `"before"` -- The component is a new element inserted before the targetElement
 in the HTML DOM. (Both the component and targetElement have the same parent
 element.)
-  * `"append"` -- The component is a new element added as a child of the
+      * `"append"` -- The component is a new element added as a child of the
 targetElement. If there are other child elements, the component is appended as
 the last child element of the targetElement.
+
+  * `audioPublisherHandler` -- An optional function that is the `completionHandler` of [`OT.initPublisher`](https://tokbox.com/developer/sdks/js/reference/OT.html#initPublisher) of the audio stream.
+  * `videoPublisherHandler` -- An optional function that is the `completionHandler` of [`OT.initPublisher`](https://tokbox.com/developer/sdks/js/reference/OT.html#initPublisher) of the video stream.
+  * `audioAccessDeniedHandler` -- An optional function that handles `accessDenied` errors of the audio stream.
+  * `videoAccessDeniedHandler` -- An optional function that handles `accessDenied` errors of the video stream.
+  * `audioLevelUpdatedHandler` -- An optional function that handles `audioLevelUpdated` events of the audio stream.
 
 * `completionHandler` -- A function that is called is called when the component
 is rendered on the page or on error in calling to the method. Upon error, this

--- a/js/opentok-hardware-setup.js
+++ b/js/opentok-hardware-setup.js
@@ -68,11 +68,9 @@ var createElement = function(nodeName, attributes, children, doc) {
         for (var n in subAttrs) {
           element[name][n] = subAttrs[n];
         }
-      }
-      else if (name === 'className') {
+      } else if (name === 'className') {
         element.className = attributes[name];
-      }
-      else {
+      } else {
         element.setAttribute(name, attributes[name]);
       }
     }
@@ -101,7 +99,7 @@ var createDevicePickerController = function(opts, changeHandler) {
       publisher,
       devicesById;
 
-  function onChange() {
+  var onChange = function onChange() {
     destroyExistingPublisher();
 
     var settings;
@@ -149,7 +147,12 @@ var createDevicePickerController = function(opts, changeHandler) {
       opts.previewTag.appendChild(audioDisplayParent);
     }
 
-    var pub = OT.initPublisher(widgetTag, settings);
+    var pub;
+    if (typeof opts.publisherHandler === 'function') {
+      pub = OT.initPublisher(widgetTag, settings, opts.publisherHandler);
+    } else {
+      pub = OT.initPublisher(widgetTag, settings);
+    }
 
     pub.on({
       accessAllowed: function() {
@@ -158,6 +161,10 @@ var createDevicePickerController = function(opts, changeHandler) {
         }
       }
     });
+
+    if (typeof opts.accessDeniedHandler === 'function') {
+      pub.on({ accessDenied: opts.accessDeniedHandler });
+    }
 
     var movingAvg = null;
 
@@ -177,11 +184,15 @@ var createDevicePickerController = function(opts, changeHandler) {
         var tagCount = audioDisplayTag.parentNode.offsetWidth / 10;
         audioDisplayTag.style.width = (Math.ceil(tagCount * logLevel) * 10) + 'px';
         // audioDisplayTag.innerHTML = (logLevel * 100).toFixed(0);
+
+        if (typeof opts.audioLevelUpdatedHandler === 'function') {
+          opts.audioLevelUpdatedHandler(event);
+        }
       });
     }
 
     publisher = pub;
-  }
+  };
 
   _devicePicker.cleanup = destroyExistingPublisher = function() {
     if(publisher) {
@@ -242,7 +253,7 @@ var createDevicePickerController = function(opts, changeHandler) {
 };
 
 var getWindowLocationProtocol = function() {
-  return window.location.protocol;
+  return (typeof window !== 'undefined') ? window.location.protocol : null;
 };
 
 var shouldGetDevices = function(callback) {
@@ -263,14 +274,16 @@ var shouldGetDevices = function(callback) {
 };
 
 var getUserMedia;
-if (navigator.getUserMedia) {
-  getUserMedia = navigator.getUserMedia.bind(navigator);
-} else if (navigator.mozGetUserMedia) {
-  getUserMedia = navigator.mozGetUserMedia.bind(navigator);
-} else if (navigator.webkitGetUserMedia) {
-  getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
-} else if (window.OTPlugin && window.OTPlugin.getUserMedia) {
-  getUserMedia = window.OTPlugin.getUserMedia.bind(window.OTPlugin);
+if (typeof window !== 'undefined') {
+  if (navigator.getUserMedia) {
+    getUserMedia = navigator.getUserMedia.bind(navigator);
+  } else if (navigator.mozGetUserMedia) {
+    getUserMedia = navigator.mozGetUserMedia.bind(navigator);
+  } else if (navigator.webkitGetUserMedia) {
+    getUserMedia = navigator.webkitGetUserMedia.bind(navigator);
+  } else if (window.OTPlugin && window.OTPlugin.getUserMedia) {
+    getUserMedia = window.OTPlugin.getUserMedia.bind(window.OTPlugin);
+  }
 }
 
 var authenticateForDeviceLabels = function(callback) {
@@ -294,8 +307,8 @@ var authenticateForDeviceLabels = function(callback) {
                 track.stop();
               });
             } else if (stream.stop) {
-             // older spec
-             stream.stop();
+              // older spec
+              stream.stop();
             }
             callback();
           }, function(error) {
@@ -309,7 +322,7 @@ var authenticateForDeviceLabels = function(callback) {
   });
 };
 
-function createOpentokHardwareSetupComponent(targetElement, options, callback) {
+var createOpentokHardwareSetupComponent = function createOpentokHardwareSetupComponent(targetElement, options, callback) {
 
   if (typeof targetElement === 'string') {
     targetElement = document.getElementById(targetElement);
@@ -418,7 +431,9 @@ function createOpentokHardwareSetupComponent(targetElement, options, callback) {
         selectTag: camSelector,
         previewTag: camPreview,
         mode: 'videoSource',
-        defaultDevice: _options.defaultVideoDevice
+        defaultDevice: _options.defaultVideoDevice,
+        publisherHandler: options.videoPublisherHandler,
+        accessDeniedHandler: options.accessDeniedHandler
       }, function(controller) {
         setPref('com.opentok.hardwaresetup.video', controller.pickedDevice.deviceId);
       });
@@ -427,7 +442,10 @@ function createOpentokHardwareSetupComponent(targetElement, options, callback) {
         selectTag: micSelector,
         previewTag: micPreview,
         mode: 'audioSource',
-        defaultDevice: _options.defaultAudioDevice
+        defaultDevice: _options.defaultAudioDevice,
+        publisherHandler: options.audioPublisherHandler,
+        accessDeniedHandler: options.accessDeniedHandler,
+        audioLevelUpdatedHandler: options.audioLevelUpdatedHandler
       }, function(controller) {
         setPref('com.opentok.hardwaresetup.audio', controller.pickedDevice.deviceId);
       });
@@ -480,5 +498,14 @@ function createOpentokHardwareSetupComponent(targetElement, options, callback) {
 
   return _hardwareSetup;
 
-}
+};
 
+if (typeof exports !== 'undefined') {
+  exports.createDevicePickerController = createDevicePickerController;
+  exports.authenticateForDeviceLabels = authenticateForDeviceLabels;
+  exports.createOpentokHardwareSetupComponent = createOpentokHardwareSetupComponent;
+} else if (typeof window !== 'undefined') {
+  window.createDevicePickerController = createDevicePickerController;
+  window.authenticateForDeviceLabels = authenticateForDeviceLabels;
+  window.createOpentokHardwareSetupComponent = createOpentokHardwareSetupComponent;
+}

--- a/js/opentok-hardware-setup.js
+++ b/js/opentok-hardware-setup.js
@@ -433,7 +433,7 @@ var createOpentokHardwareSetupComponent = function createOpentokHardwareSetupCom
         mode: 'videoSource',
         defaultDevice: _options.defaultVideoDevice,
         publisherHandler: options.videoPublisherHandler,
-        accessDeniedHandler: options.accessDeniedHandler
+        accessDeniedHandler: options.videoAccessDeniedHandler
       }, function(controller) {
         setPref('com.opentok.hardwaresetup.video', controller.pickedDevice.deviceId);
       });
@@ -444,7 +444,7 @@ var createOpentokHardwareSetupComponent = function createOpentokHardwareSetupCom
         mode: 'audioSource',
         defaultDevice: _options.defaultAudioDevice,
         publisherHandler: options.audioPublisherHandler,
-        accessDeniedHandler: options.accessDeniedHandler,
+        accessDeniedHandler: options.audioAccessDeniedHandler,
         audioLevelUpdatedHandler: options.audioLevelUpdatedHandler
       }, function(controller) {
         setPref('com.opentok.hardwaresetup.audio', controller.pickedDevice.deviceId);

--- a/tests/spec/hardwaresetup_spec.js
+++ b/tests/spec/hardwaresetup_spec.js
@@ -421,14 +421,19 @@ describe('opentok.js hardware setup component', function() {
         selectTag: jasmine.any(Node),
         previewTag: jasmine.any(Node),
         mode: 'videoSource',
-        defaultDevice: null
+        defaultDevice: null,
+        publisherHandler: undefined,
+        accessDeniedHandler: undefined
       }, jasmine.any(Function));
 
       expect(window.createDevicePickerController).toHaveBeenCalledWith({
         selectTag: jasmine.any(Node),
         previewTag: jasmine.any(Node),
         mode: 'audioSource',
-        defaultDevice: null
+        defaultDevice: null,
+        publisherHandler: undefined,
+        accessDeniedHandler: undefined,
+        audioLevelUpdatedHandler: undefined
       }, jasmine.any(Function));
 
       expect(microphone.setLoading).toHaveBeenCalled();


### PR DESCRIPTION
Right now the only error messages you get are if the test setup itself fails; all errors from the `OT.Publisher` are left unhandled (and just dump to the console). This PR allows the client to handle these errors to give a more accurate sense of the problem (such as whether the hardware isn't there, whether the browser is blocking it, whether the mic is muted, etc.).

I've also modified the references to `window` so that this can be used in node.js and webpack environments where the `window` variable isn't declared.

I've updated the tests and the docs accordingly. Let me know if you have any questions, comments, or concerns.
