### PR TITLE
prefer navigator.mediaDevices.getUserMedia

### DIFF
--- a/js/opentok-hardware-setup.js
+++ b/js/opentok-hardware-setup.js
@@ -263,7 +263,11 @@ var shouldGetDevices = function(callback) {
 };
 
 var getUserMedia;
-if (navigator.getUserMedia) {
+if (navigator.mediaDevices && navigator.mediaDevices.getUserMedia) {
+  getUserMedia = function(constraints, onStream, onError) {
+    navigator.mediaDevices.getUserMedia(constraints).then(onStream, onError);
+  };
+} else if (navigator.getUserMedia) {
   getUserMedia = navigator.getUserMedia.bind(navigator);
 } else if (navigator.mozGetUserMedia) {
   getUserMedia = navigator.mozGetUserMedia.bind(navigator);


### PR DESCRIPTION
otherwise Firefox complains about the usage of the navigator.mozGetUserMedia
